### PR TITLE
Wrap long lines to satisfy flake8

### DIFF
--- a/catholic_calendar/calendar.py
+++ b/catholic_calendar/calendar.py
@@ -149,7 +149,10 @@ def _normalise_event(
     description_lines: List[str] = []
     description_pairs = [
         ("Rank", event.get("rankName") or event.get("rank")),
-        ("Liturgical color", event.get("liturgicalColor") or event.get("liturgicalColors")),
+        (
+            "Liturgical color",
+            event.get("liturgicalColor") or event.get("liturgicalColors"),
+        ),
         ("Season", event.get("season") or event.get("liturgicalSeason")),
         ("Type", event.get("type") or event.get("liturgicalType")),
         ("Holy day of obligation", event.get("isHolyDayOfObligation")),
@@ -161,9 +164,13 @@ def _normalise_event(
     if notes:
         description_pairs.append(("Notes", notes))
 
-    commemorations = event.get("commemorations") or event.get("secondaryCelebrations")
+    commemorations = event.get("commemorations") or event.get(
+        "secondaryCelebrations"
+    )
     if commemorations:
-        description_lines.append("Commemorations: " + _stringify(commemorations))
+        description_lines.append(
+            "Commemorations: " + _stringify(commemorations)
+        )
 
     metadata = event.get("metadata") or event.get("meta")
     if metadata:

--- a/catholic_calendar/cli.py
+++ b/catholic_calendar/cli.py
@@ -78,29 +78,32 @@ def parse_args(args: Sequence[str] | None = None) -> argparse.Namespace:
         "--method",
         default="PUBLISH",
         help=(
-            "Value to expose via the calendar METHOD property (default: PUBLISH). "
-            "Pass an empty string to omit the property."
+            "Value to expose via the calendar METHOD property "
+            "(default: PUBLISH). Pass an empty string to omit the property."
         ),
     )
     parser.add_argument(
         "--refresh-interval",
         default="P1D",
         help=(
-            "Duration advertised through REFRESH-INTERVAL;VALUE=DURATION (default: P1D). "
-            "Pass an empty string to omit the property."
+            "Duration advertised through REFRESH-INTERVAL;VALUE=DURATION "
+            "(default: P1D). Pass an empty string to omit the property."
         ),
     )
     parser.add_argument(
         "--published-ttl",
         default="P1D",
         help=(
-            "Duration advertised through X-PUBLISHED-TTL (default: P1D). "
-            "Pass an empty string to omit the property."
+            "Duration advertised through X-PUBLISHED-TTL "
+            "(default: P1D). Pass an empty string to omit the property."
         ),
     )
     parser.add_argument(
         "--romcal-script",
-        help="Path to a custom romcal bridge script (defaults to the bundled script).",
+        help=(
+            "Path to a custom romcal bridge script "
+            "(defaults to the bundled script)."
+        ),
     )
     optional_group = parser.add_mutually_exclusive_group()
     optional_group.add_argument(

--- a/catholic_calendar/romcal_adapter.py
+++ b/catholic_calendar/romcal_adapter.py
@@ -33,7 +33,16 @@ def fetch_calendar(
     if not script.exists():  # pragma: no cover - defensive branch
         raise FileNotFoundError(f"romcal bridge script not found at {script}")
 
-    command = ["node", str(script), "--year", str(year), "--locale", locale, "--calendar", calendar]
+    command = [
+        "node",
+        str(script),
+        "--year",
+        str(year),
+        "--locale",
+        locale,
+        "--calendar",
+        calendar,
+    ]
     if not include_optional:
         command.append("--no-optional")
     if extra_args:
@@ -50,7 +59,8 @@ def fetch_calendar(
     try:
         payload = json.loads(stdout)
     except json.JSONDecodeError as exc:  # pragma: no cover - defensive branch
-        raise RomcalRuntimeError("romcal bridge script did not return valid JSON") from exc
+        message = "romcal bridge script did not return valid JSON"
+        raise RomcalRuntimeError(message) from exc
 
     if not isinstance(payload, list):  # pragma: no cover - defensive branch
         raise RomcalRuntimeError("romcal bridge script must output a JSON array")

--- a/catholic_calendar/tests/test_calendar.py
+++ b/catholic_calendar/tests/test_calendar.py
@@ -69,14 +69,25 @@ def test_build_calendar_contains_expected_events(sample_events):
     events = _extract_events(ics)
     assert len(events) == len(sample_events)
 
-    summaries = {line.split(":", 1)[1] for event in events for line in event if line.startswith("SUMMARY:")}
+    summaries = {
+        line.split(":", 1)[1]
+        for event in events
+        for line in event
+        if line.startswith("SUMMARY:")
+    }
     assert "Mary\\, Mother of God" in summaries
     assert "Easter Sunday" in summaries
 
-    easter_event = next(event for event in events if any(line.endswith("Easter Sunday") for line in event))
+    easter_event = next(
+        event
+        for event in events
+        if any(line.endswith("Easter Sunday") for line in event)
+    )
     dtstart_line = next(line for line in easter_event if line.startswith("DTSTART"))
     assert dtstart_line.endswith("20250420")
-    description_line = next(line for line in easter_event if line.startswith("DESCRIPTION:"))
+    description_line = next(
+        line for line in easter_event if line.startswith("DESCRIPTION:")
+    )
     assert "Commemorations" in description_line
     assert "Season" in description_line
 

--- a/catholic_calendar/tests/test_cli.py
+++ b/catholic_calendar/tests/test_cli.py
@@ -61,7 +61,12 @@ def test_main_creates_calendar(tmp_output: Path, monkeypatch):
     assert tmp_output.exists()
     ics = tmp_output.read_text(encoding="utf-8")
     events = _extract_events(ics)
-    summaries = {line.split(":", 1)[1] for event in events for line in event if line.startswith("SUMMARY:")}
+    summaries = {
+        line.split(":", 1)[1]
+        for event in events
+        for line in event
+        if line.startswith("SUMMARY:")
+    }
     assert "Mary 2025" in summaries
     assert "Mary 2026" in summaries
 


### PR DESCRIPTION
## Summary
- break long romcal adapter command and error message to satisfy flake8's 88 character limit
- reflow CLI help text and related tests so linting and tox succeed

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1a2de3b1083208edbd4d04197cf81